### PR TITLE
Support Precogs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ sponge.plugin.id = pluginId
 repositories {
     mavenCentral()
     maven { url 'https://dl.bintray.com/me4502/maven' }
+    maven { url 'https://jitpack.io' }
 }
 
 dependencies {
@@ -31,6 +32,7 @@ dependencies {
     compile 'org.spongepowered:spongeapi:6.0.0-SNAPSHOT'
     compile 'com.zaxxer:HikariCP:2.6.0'
     compile 'com.me4502:ModularFramework:1.8.3'
+    compile 'com.github.Me4502:Precogs:-SNAPSHOT'
 }
 
 if (JavaVersion.current().isJava8Compatible()) {

--- a/src/main/java/io/github/connorhartley/guardian/Guardian.java
+++ b/src/main/java/io/github/connorhartley/guardian/Guardian.java
@@ -28,6 +28,7 @@ import com.me4502.modularframework.ModuleController;
 import com.me4502.modularframework.ShadedModularFramework;
 import com.me4502.modularframework.exception.ModuleNotInstantiatedException;
 import com.me4502.modularframework.module.ModuleWrapper;
+import com.me4502.precogs.service.AntiCheatService;
 import io.github.connorhartley.guardian.data.handler.SequenceHandlerData;
 import io.github.connorhartley.guardian.data.tag.OffenseTagData;
 import io.github.connorhartley.guardian.detection.Detection;
@@ -35,6 +36,7 @@ import io.github.connorhartley.guardian.detection.check.Check;
 import io.github.connorhartley.guardian.detection.check.CheckController;
 import io.github.connorhartley.guardian.sequence.Sequence;
 import io.github.connorhartley.guardian.sequence.SequenceController;
+import io.github.connorhartley.guardian.service.GuardianAntiCheatService;
 import ninja.leaping.configurate.ConfigurationOptions;
 import ninja.leaping.configurate.commented.CommentedConfigurationNode;
 import ninja.leaping.configurate.loader.ConfigurationLoader;
@@ -46,10 +48,12 @@ import org.spongepowered.api.event.Listener;
 import org.spongepowered.api.event.filter.cause.First;
 import org.spongepowered.api.event.game.GameReloadEvent;
 import org.spongepowered.api.event.game.state.GameInitializationEvent;
+import org.spongepowered.api.event.game.state.GamePreInitializationEvent;
 import org.spongepowered.api.event.game.state.GameStartedServerEvent;
 import org.spongepowered.api.event.game.state.GameStartingServerEvent;
 import org.spongepowered.api.event.game.state.GameStoppingEvent;
 import org.spongepowered.api.event.network.ClientConnectionEvent;
+import org.spongepowered.api.plugin.Dependency;
 import org.spongepowered.api.plugin.Plugin;
 import org.spongepowered.api.plugin.PluginContainer;
 
@@ -62,7 +66,10 @@ import java.io.File;
         description = "An extensible anticheat plugin for Sponge.",
         authors = {
                 "Connor Hartley (vectrix)"
-        }
+        },
+        dependencies = @Dependency(
+                id = "precogs"
+        )
 )
 public class Guardian {
 
@@ -127,6 +134,13 @@ public class Guardian {
     private SequenceController.SequenceControllerTask sequenceControllerTask;
 
     /* Game Events */
+
+    @Listener
+    public void onGamePreInitialize(GamePreInitializationEvent event) {
+        Sponge.getServiceManager().setProvider(this, AntiCheatService.class, new GuardianAntiCheatService());
+
+        // TODO Register all of the DetectionType to GameRegistry.
+    }
 
     @Listener
     public void onGameInitialize(GameInitializationEvent event) {

--- a/src/main/java/io/github/connorhartley/guardian/internal/detections/DummyDetection.java
+++ b/src/main/java/io/github/connorhartley/guardian/internal/detections/DummyDetection.java
@@ -38,7 +38,7 @@ import java.util.List;
 import java.util.Optional;
 
 @Module(id = "dummydetection", name = "DummyDetection", version = "0.0.1", onEnable = "onConstruction", onDisable = "onDeconstruction")
-public class DummyDetection implements Detection {
+public class DummyDetection extends Detection {
 
     @Inject
     @ModuleContainer

--- a/src/main/java/io/github/connorhartley/guardian/internal/detections/DummyDetection.java
+++ b/src/main/java/io/github/connorhartley/guardian/internal/detections/DummyDetection.java
@@ -49,6 +49,10 @@ public class DummyDetection extends Detection {
 
     private boolean ready = false;
 
+    public DummyDetection(String id, String name) {
+        super(id, name);
+    }
+
     @Override
     public void onConstruction() {
         if (!this.moduleContainer.getInstance().isPresent());

--- a/src/main/java/io/github/connorhartley/guardian/internal/detections/SpeedDetection.java
+++ b/src/main/java/io/github/connorhartley/guardian/internal/detections/SpeedDetection.java
@@ -41,7 +41,7 @@ import java.util.List;
 import java.util.Optional;
 
 @Module(id = "speed_detection", name = "Speed Detection", version = "0.0.1", onEnable = "onConstruction", onDisable = "onDeconstruction")
-public class SpeedDetection implements Detection, StorageConsumer {
+public class SpeedDetection extends Detection implements StorageConsumer {
 
     @Inject
     @ModuleContainer

--- a/src/main/java/io/github/connorhartley/guardian/internal/detections/SpeedDetection.java
+++ b/src/main/java/io/github/connorhartley/guardian/internal/detections/SpeedDetection.java
@@ -52,6 +52,10 @@ public class SpeedDetection extends Detection implements StorageConsumer {
 
     private boolean ready = false;
 
+    public SpeedDetection(String id, String name) {
+        super(id, name);
+    }
+
     @Override
     public void onConstruction() {
         if (!this.moduleContainer.getInstance().isPresent());

--- a/src/main/java/io/github/connorhartley/guardian/service/GuardianAntiCheatService.java
+++ b/src/main/java/io/github/connorhartley/guardian/service/GuardianAntiCheatService.java
@@ -21,56 +21,32 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package io.github.connorhartley.guardian.detection;
+package io.github.connorhartley.guardian.service;
 
 import com.me4502.precogs.detection.DetectionType;
-import io.github.connorhartley.guardian.detection.check.CheckProvider;
+import com.me4502.precogs.service.AntiCheatService;
+import com.me4502.precogs.service.BypassTicket;
+import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.entity.living.player.User;
 
 import java.util.List;
+import java.util.Optional;
 
-/**
- * Detection
- *
- * Represents a cheat / hack / exploit internal that is loaded
- * by the global detection manager.
- */
-public abstract class Detection extends DetectionType {
+public class GuardianAntiCheatService implements AntiCheatService {
 
-    public Detection(String id, String name) {
-        super(id, name);
+    @Override
+    public Optional<BypassTicket> requestBypassTicket(Player player, List<DetectionType> list) {
+        return Optional.of(new GuardianBypassTicket(player, list));
     }
 
-    /**
-     * On Construction
-     *
-     * <p>Invoked when the internal is enabled.</p>
-     */
-    public abstract void onConstruction();
+    @Override
+    public double getViolationLevel(User user, DetectionType detectionType) {
+        // TODO
+        return 0;
+    }
 
-    /**
-     * On Deconstruction
-     *
-     * <p>Invoked when the internal is disabled.</p>
-     */
-    public abstract void onDeconstruction();
-
-    /**
-     * Is Ready
-     *
-     * <p>True when the detection has finished loading and false when it is not,
-     * or being deconstructed.</p>
-     *
-     * @return True when ready, false when not
-     */
-    public abstract boolean isReady();
-
-    /**
-     * Get Checks
-     *
-     * <p>Returns the {@link CheckProvider}s that this {@link Detection} uses.</p>
-     *
-     * @return Check providers for this detection
-     */
-    public abstract List<CheckProvider> getChecks();
-
+    @Override
+    public void logViolation(User user, DetectionType detectionType, double v) {
+        // TODO
+    }
 }

--- a/src/main/java/io/github/connorhartley/guardian/service/GuardianBypassTicket.java
+++ b/src/main/java/io/github/connorhartley/guardian/service/GuardianBypassTicket.java
@@ -21,56 +21,37 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package io.github.connorhartley.guardian.detection;
+package io.github.connorhartley.guardian.service;
 
 import com.me4502.precogs.detection.DetectionType;
-import io.github.connorhartley.guardian.detection.check.CheckProvider;
+import com.me4502.precogs.service.BypassTicket;
+import org.spongepowered.api.entity.living.player.Player;
 
 import java.util.List;
 
-/**
- * Detection
- *
- * Represents a cheat / hack / exploit internal that is loaded
- * by the global detection manager.
- */
-public abstract class Detection extends DetectionType {
+public class GuardianBypassTicket implements BypassTicket {
 
-    public Detection(String id, String name) {
-        super(id, name);
+    private Player player;
+    private List<DetectionType> detectionTypes;
+
+    public GuardianBypassTicket(Player player, List<DetectionType> detectionTypes) {
+        this.player = player;
+        this.detectionTypes = detectionTypes;
+        // TODO Disable the detections.
     }
 
-    /**
-     * On Construction
-     *
-     * <p>Invoked when the internal is enabled.</p>
-     */
-    public abstract void onConstruction();
+    @Override
+    public Player getPlayer() {
+        return this.player;
+    }
 
-    /**
-     * On Deconstruction
-     *
-     * <p>Invoked when the internal is disabled.</p>
-     */
-    public abstract void onDeconstruction();
+    @Override
+    public List<DetectionType> getDetectionTypes() {
+        return this.detectionTypes;
+    }
 
-    /**
-     * Is Ready
-     *
-     * <p>True when the detection has finished loading and false when it is not,
-     * or being deconstructed.</p>
-     *
-     * @return True when ready, false when not
-     */
-    public abstract boolean isReady();
-
-    /**
-     * Get Checks
-     *
-     * <p>Returns the {@link CheckProvider}s that this {@link Detection} uses.</p>
-     *
-     * @return Check providers for this detection
-     */
-    public abstract List<CheckProvider> getChecks();
-
+    @Override
+    public void close() {
+        // TODO Enable the detections.
+    }
 }


### PR DESCRIPTION
Precogs is an AntiCheat service API that we will support. Meaning if you're plugins conflict with the AntiCheat you will be able to control detections through it's lightweight API. This isn't quite ready to be merged yet, but is coming.